### PR TITLE
Video generator

### DIFF
--- a/server/.cargo/config.toml
+++ b/server/.cargo/config.toml
@@ -1,0 +1,3 @@
+# https://github.com/rust-lang/rust/issues/28924#issuecomment-442260036
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -15,12 +15,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "adler2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
-
-[[package]]
 name = "adler32"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,15 +51,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "approx"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,16 +69,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
 name = "bindgen"
-version = "0.69.4"
+version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
  "bitflags 2.6.0",
  "cexpr",
@@ -129,9 +108,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
+checksum = "8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d"
 
 [[package]]
 name = "byteorder"
@@ -141,12 +120,10 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.1.28"
+version = "1.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e80e3b6a3ab07840e1cae9b0666a63970dc28e8ed5ffbcdacbfc760c281bfc1"
+checksum = "b16803a61b81d9eabb7eae2588776c4c1e584b738ede45fdbb4c972cec1e9945"
 dependencies = [
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -179,9 +156,7 @@ checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "js-sys",
  "num-traits",
- "wasm-bindgen",
  "windows-targets",
 ]
 
@@ -261,12 +236,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cty"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
-
-[[package]]
 name = "deflate"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,7 +280,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58b8d57d7c11c2084f7cfedfc661a8714c8ddea793291ffec4e5719e96487e7b"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "embedded-graphics",
  "image",
  "ouroboros",
@@ -335,42 +304,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
-name = "flate2"
-version = "1.0.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
-dependencies = [
- "crc32fast",
- "miniz_oxide 0.8.0",
-]
-
-[[package]]
 name = "float-cmp"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "form_urlencoded"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
-dependencies = [
- "percent-encoding",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
 ]
 
 [[package]]
@@ -419,16 +358,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "idna"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
 name = "image"
 version = "0.23.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,18 +369,12 @@ dependencies = [
  "gif",
  "jpeg-decoder",
  "num-iter",
- "num-rational 0.3.2",
+ "num-rational",
  "num-traits",
  "png",
  "scoped_threadpool",
  "tiff",
 ]
-
-[[package]]
-name = "iter-read"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c397ca3ea05ad509c4ec451fea28b4771236a376ca1c69fd5143aae0cf8f93c4"
 
 [[package]]
 name = "itertools"
@@ -460,15 +383,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
-]
-
-[[package]]
-name = "jobserver"
-version = "0.1.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -482,18 +396,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "json"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "lazy_static"
@@ -524,16 +432,6 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
-
-[[package]]
-name = "matrixmultiply"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9380b911e3e96d10c1f415da0876389aaf1b56759054eeb0de7df940c456ba1a"
-dependencies = [
- "autocfg",
- "rawpointer",
-]
 
 [[package]]
 name = "memchr"
@@ -573,56 +471,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
-dependencies = [
- "adler2",
-]
-
-[[package]]
-name = "nalgebra"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c4b5f057b303842cf3262c27e465f4c303572e7f6b0648f60e16248ac3397f4"
-dependencies = [
- "approx",
- "matrixmultiply",
- "nalgebra-macros",
- "num-complex",
- "num-rational 0.4.2",
- "num-traits",
- "serde",
- "simba",
- "typenum",
-]
-
-[[package]]
-name = "nalgebra-macros"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.79",
-]
-
-[[package]]
-name = "ndarray"
-version = "0.15.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
-dependencies = [
- "matrixmultiply",
- "num-complex",
- "num-integer",
- "num-traits",
- "rawpointer",
-]
-
-[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,26 +503,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
- "serde",
-]
-
-[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,17 +529,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
 dependencies = [
  "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -771,18 +588,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "percent-encoding"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -834,16 +639,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "process_path"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f676f11eb0b3e2ea0fbaee218fa6b806689e2297b8c8adc5bf73df465c4f6171"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,12 +646,6 @@ checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "rawpointer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -906,21 +695,6 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
-
-[[package]]
-name = "ring"
-version = "0.17.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom",
- "libc",
- "spin",
- "untrusted",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "rpi-led-matrix"
@@ -975,76 +749,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls"
-version = "0.23.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "415d9944693cb90382053259f89fbb077ea730ad7273047ec63b19bc9b160ba8"
-dependencies = [
- "log",
- "once_cell",
- "ring",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls-pki-types"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
-]
-
-[[package]]
-name = "safe_arch"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3460605018fdc9612bce72735cba0d27efbcd9904780d44c7e3a9948f96148a"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "satkit"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c997791465d1d7bb12e16ea3b0e1f435facb7962c2215aadd96413b596f0ab8f"
-dependencies = [
- "cc",
- "chrono",
- "cty",
- "json",
- "libc",
- "nalgebra",
- "ndarray",
- "num-traits",
- "once_cell",
- "process_path",
- "serde",
- "serde-pickle",
- "simba",
- "thiserror",
- "ureq",
 ]
 
 [[package]]
@@ -1086,19 +796,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-pickle"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c762ad136a26407c6a80825813600ceeab5e613660d93d79a41f0ec877171e71"
-dependencies = [
- "byteorder",
- "iter-read",
- "num-bigint",
- "num-traits",
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1121,7 +818,6 @@ dependencies = [
  "num_cpus",
  "rpi-led-matrix",
  "rs_ws281x",
- "satkit",
  "tempfile",
  "tracing",
  "tracing-subscriber",
@@ -1143,35 +839,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "simba"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a386a501cd104797982c15ae17aafe8b9261315b5d07e3ec803f2ea26be0fa"
-dependencies = [
- "approx",
- "num-complex",
- "num-traits",
- "paste",
- "wide",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
-name = "subtle"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1209,26 +880,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.79",
-]
-
-[[package]]
 name = "thread_local"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,21 +899,6 @@ dependencies = [
  "miniz_oxide 0.4.4",
  "weezl",
 ]
-
-[[package]]
-name = "tinyvec"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tracing"
@@ -1322,64 +958,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "typenum"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
-name = "unicode-bidi"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "ureq"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b74fc6b57825be3373f7054754755f03ac3a8f5d70015ccad699ba2029956f4a"
-dependencies = [
- "base64 0.22.1",
- "flate2",
- "log",
- "once_cell",
- "rustls",
- "rustls-pki-types",
- "url",
- "webpki-roots",
-]
-
-[[package]]
-name = "url"
-version = "2.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
-]
 
 [[package]]
 name = "valuable"
@@ -1410,16 +992,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1428,9 +1004,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
@@ -1443,9 +1019,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1453,9 +1029,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1466,34 +1042,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
-dependencies = [
- "rustls-pki-types",
-]
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "weezl"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
-
-[[package]]
-name = "wide"
-version = "0.7.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b828f995bf1e9622031f8009f8481a85406ce1f4d4588ff746d872043e855690"
-dependencies = [
- "bytemuck",
- "safe_arch",
-]
 
 [[package]]
 name = "winapi"
@@ -1616,9 +1173,3 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "zeroize"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -319,6 +319,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+
+[[package]]
 name = "flate2"
 version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,6 +388,12 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "iana-time-zone"
@@ -490,6 +512,12 @@ name = "libc"
 version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "log"
@@ -695,6 +723,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -924,6 +962,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustix"
+version = "0.38.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+dependencies = [
+ "bitflags 2.6.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1067,9 +1118,11 @@ dependencies = [
  "embedded-graphics",
  "embedded-graphics-core",
  "embedded-graphics-simulator",
+ "num_cpus",
  "rpi-led-matrix",
  "rs_ws281x",
  "satkit",
+ "tempfile",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1140,6 +1193,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -11,8 +11,10 @@ ctrlc = "3.4.5"
 embedded-graphics = "0.7.1"
 embedded-graphics-core = "0.3.3"
 embedded-graphics-simulator = { version = "0.4.1", optional = true }
+num_cpus = { version = "1.16.0", optional = true }
 rs_ws281x = "0.5.1"
 satkit = "0.3.11"
+tempfile = { version = "3.13.0", optional = true }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 
@@ -24,5 +26,9 @@ rpi-led-matrix = {version = "0.4.0", features = ["c-stubs", "embeddedgraphics"]}
 
 [features]
 simulator = ["dep:embedded-graphics-simulator"]
-# default = ["simulator"]
+default = ["video"]
+video = ["simulator", "dep:tempfile", "dep:num_cpus"]
 
+[[bin]]
+name = "video"
+required-features = ["video"]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -13,7 +13,6 @@ embedded-graphics-core = "0.3.3"
 embedded-graphics-simulator = { version = "0.4.1", optional = true }
 num_cpus = { version = "1.16.0", optional = true }
 rs_ws281x = "0.5.1"
-satkit = "0.3.11"
 tempfile = { version = "3.13.0", optional = true }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"

--- a/server/src/bin/riseset.rs
+++ b/server/src/bin/riseset.rs
@@ -2,39 +2,17 @@
 //!
 //! Print a table of ephemerides: for each hour of the next year, the next rise and set times.
 
-use chrono::{DateTime, Datelike, Local, Timelike};
-use satkit::{lpephem::sun::riseset, AstroTime, ITRFCoord};
-
-/// Get the rise and set times from the satkit library,
-/// converted to chrono time units
-fn get_riseset(time: DateTime<Local>) -> (DateTime<Local>, DateTime<Local>) {
-    // Washington, DC, approximately
-    let coord = ITRFCoord::from_geodetic_deg(39.0, -77.0, 10.0);
-
-    // The docstring for riseset says "time is at location, and should have hours, minutes, and seconds set to zero"
-    // which... is a little confusing, since there's a "unix time" constructor,
-    // but whatever.
-    // The rise/set tables are nonsensical if I provide fractional days (Unix timestamps),
-    // shifting over the course of a day.
-    let time = &AstroTime::from_date(time.year(), time.month(), time.day());
-
-    let (a, b) = riseset(time, &coord, None).unwrap();
-    let [a, b] = [a, b].map(|v| {
-        DateTime::from_timestamp(v.to_unixtime() as i64, 0)
-            .unwrap()
-            .with_timezone(&Local)
-    });
-    let (rise, set) = if a.hour() < b.hour() { (a, b) } else { (b, a) };
-    (rise, set)
-}
+use chrono::{Datelike, Local};
+use server::riseset::riseset;
 
 fn main() {
-    let mut now = Local::now();
-    let end = now + chrono::Duration::days(365);
+    tracing_subscriber::fmt::init();
+    let mut now = Local::now().with_month(1).unwrap().with_day(1).unwrap();
+    let end = now + chrono::Duration::days(366);
 
     while now < end {
-        let (rise, set) = get_riseset(now);
-        println!("{rise} // {set}");
+        let (rise, snoon, set) = riseset(now, 39.0, -77.0);
+        println!("{rise} // {snoon} // {set}");
         now += chrono::Duration::days(1);
     }
 }

--- a/server/src/bin/riseset.rs
+++ b/server/src/bin/riseset.rs
@@ -1,0 +1,40 @@
+//! Reasonableness check on the satkit rise/set times.
+//!
+//! Print a table of ephemerides: for each hour of the next year, the next rise and set times.
+
+use chrono::{DateTime, Datelike, Local, Timelike};
+use satkit::{lpephem::sun::riseset, AstroTime, ITRFCoord};
+
+/// Get the rise and set times from the satkit library,
+/// converted to chrono time units
+fn get_riseset(time: DateTime<Local>) -> (DateTime<Local>, DateTime<Local>) {
+    // Washington, DC, approximately
+    let coord = ITRFCoord::from_geodetic_deg(39.0, -77.0, 10.0);
+
+    // The docstring for riseset says "time is at location, and should have hours, minutes, and seconds set to zero"
+    // which... is a little confusing, since there's a "unix time" constructor,
+    // but whatever.
+    // The rise/set tables are nonsensical if I provide fractional days (Unix timestamps),
+    // shifting over the course of a day.
+    let time = &AstroTime::from_date(time.year(), time.month(), time.day());
+
+    let (a, b) = riseset(time, &coord, None).unwrap();
+    let [a, b] = [a, b].map(|v| {
+        DateTime::from_timestamp(v.to_unixtime() as i64, 0)
+            .unwrap()
+            .with_timezone(&Local)
+    });
+    let (rise, set) = if a.hour() < b.hour() { (a, b) } else { (b, a) };
+    (rise, set)
+}
+
+fn main() {
+    let mut now = Local::now();
+    let end = now + chrono::Duration::days(365);
+
+    while now < end {
+        let (rise, set) = get_riseset(now);
+        println!("{rise} // {set}");
+        now += chrono::Duration::days(1);
+    }
+}

--- a/server/src/bin/video.rs
+++ b/server/src/bin/video.rs
@@ -1,0 +1,104 @@
+//! Generates a video of the display for a whole day/year.
+
+use std::{
+    ops::Range,
+    path::Path,
+    time::{Duration, Instant},
+};
+
+use chrono::{DateTime, Local};
+use server::{context::Context, edge::get_pixels, face::get_clock};
+use tempfile::NamedTempFile;
+
+/// Make screen samples starting from the start time, stepping by the duration, and put them in the
+/// output path.
+///
+/// Only produces the (offset)th samples of (parallel_count);
+/// e.g. with offset=1 and parallel_count = 4, produces the 1th, 5th, 9th, etc. multiples of step.
+fn make_samples(
+    ctx: &Context,
+    when: Range<DateTime<Local>>,
+    step: Duration,
+    offset: u32,
+    parallel_count: u32,
+    outdir: &Path,
+) {
+    let mut displays = server::simulator::SimDisplays::new_hidden();
+
+    let end = when.end;
+
+    for i in 0.. {
+        let t = when.start + step * (i * parallel_count + offset);
+        if t > end || ctx.is_cancelled() {
+            break;
+        }
+        let start = Instant::now();
+        get_clock(t, &mut displays);
+        get_pixels(t, &mut displays).unwrap();
+        let buffer = displays.screenshot();
+        let rendered = Instant::now();
+
+        let path = outdir.join(format!("{i:04}.png"));
+        buffer.save_png(&path).unwrap();
+        let saved = Instant::now();
+        // Note: the --release build of the PNG writer is _much_ faster.
+        tracing::trace!(
+            "{:04} -- {:03} rendering, {:03} saving",
+            i,
+            (rendered - start).as_millis(),
+            (saved - rendered).as_millis()
+        );
+    }
+}
+
+pub fn main() {
+    tracing_subscriber::fmt::init();
+
+    let outfile = {
+        let outfile = NamedTempFile::with_suffix(".webp").unwrap();
+        outfile.path().to_owned()
+    };
+    let ctx = server::context::Context::new();
+    {
+        let ctx = ctx.clone();
+        ctrlc::set_handler(move || {
+            tracing::info!("got SIGINT, closing context");
+            ctx.cancel();
+        })
+        .expect("could not set SIGINT handler");
+    }
+
+    let output = tempfile::Builder::new().keep(false).tempdir().unwrap();
+    let n: u32 = num_cpus::get().try_into().unwrap();
+    let start = Local::now();
+    let end = start + Duration::from_secs(365 * 24 * 60 * 60);
+    let step = Duration::from_secs(24 * 60 * 60);
+    tracing::info!("starting frame generation...");
+    std::thread::scope(|scope| {
+        for i in 0u32..n {
+            let ctx = &ctx;
+            let outdir = output.path();
+            scope.spawn(move || make_samples(ctx, start..end, step, i, n, outdir));
+        }
+    });
+
+    tracing::info!("output frames in {}", output.path().display());
+    let c = std::process::Command::new("ffmpeg")
+        .arg("-i")
+        .arg(format!("{}/%04d.png", output.path().display()))
+        .arg("-loop")
+        .arg("0") // infinite loop
+        .arg("-y") // OK to overwrite
+        .arg(&outfile)
+        .output()
+        .expect("could not run ffmpeg");
+    if !c.status.success() {
+        tracing::error!("ffmpeg failed: {}", c.status);
+        if let Ok(s) = std::str::from_utf8(&c.stderr) {
+            tracing::error!("ffmpeg output: {}", s);
+        }
+        std::process::exit(2);
+    }
+    tracing::info!("video in {}", outfile.display());
+    tracing::info!("file://{}", outfile.display());
+}

--- a/server/src/bin/video.rs
+++ b/server/src/bin/video.rs
@@ -88,6 +88,8 @@ pub fn main() {
         .arg(format!("{}/%04d.png", output.path().display()))
         .arg("-loop")
         .arg("0") // infinite loop
+        .arg("-filter:v")
+        .arg("fps=15")
         .arg("-y") // OK to overwrite
         .arg(&outfile)
         .output()

--- a/server/src/edge.rs
+++ b/server/src/edge.rs
@@ -36,20 +36,19 @@ pub fn get_pixels(time: DateTime<Local>, displays: &mut impl Displays) -> Result
     // but they may be (rise, set) or (set, rise) depending on the specified time.
 
     tracing::trace!("next: {} after: {}", a, b);
+    let [a, b] = [a, b].map(|v| {
+        DateTime::from_timestamp(v.to_unixtime() as i64, 0).expect("could not convert datetime")
+    });
+    let (rise, set) = if a.hour() < b.hour() { (a, b) } else { (b, a) };
     // Convert both of them to coordinates around the face.
-    let [a, b]: [f32; 2] = [a, b]
-        .map(|v| {
-            DateTime::from_timestamp(v.to_unixtime() as i64, 0).expect("could not convert datetime")
-        })
-        .map(|v: DateTime<Utc>| {
-            let time = v.with_timezone(&Local).time();
-            tracing::trace!("local: {}", time);
-            let h = time.hour();
-            let m = time.minute();
-            // Convert to a fraction of the day, at a minute granualirty.
-            (h * 60 + m) as f32 / (24 * 60) as f32
-        });
-    let (rise, set) = if a > b { (b, a) } else { (a, b) };
+    let [rise, set] = [rise, set].map(|v: DateTime<Utc>| {
+        let time = v.with_timezone(&Local).time();
+        tracing::trace!("local: {}", time);
+        let h = time.hour();
+        let m = time.minute();
+        // Convert to a fraction of the day, at a minute granualirty.
+        (h * 60 + m) as f32 / (24 * 60) as f32
+    });
 
     let daylight = set - rise;
 

--- a/server/src/face.rs
+++ b/server/src/face.rs
@@ -1,10 +1,11 @@
 //! Drawing routines for the face of the clock.
 
-use chrono::{DateTime, Local, Timelike};
+use chrono::{DateTime, Datelike, Local, Timelike};
+use embedded_graphics::text::{Alignment, Baseline, TextStyleBuilder};
 use embedded_graphics::Drawable;
 use embedded_graphics::{
     geometry::{Point, Size},
-    mono_font::{ascii::FONT_4X6, MonoTextStyle},
+    mono_font::{ascii::FONT_4X6, ascii::FONT_6X9, MonoTextStyle},
     primitives::{Primitive, PrimitiveStyleBuilder, Rectangle},
     text::Text,
 };
@@ -13,12 +14,34 @@ use embedded_graphics_core::pixelcolor::RgbColor;
 
 use crate::Displays;
 
+/// Enblish 3-character month abbreviations.
+fn month_en3(number: u32) -> &'static str {
+    match number {
+        1 => "JAN",
+        2 => "FEB",
+        3 => "MAR",
+        4 => "APR",
+        5 => "MAY",
+        6 => "JUN",
+        7 => "JUL",
+        8 => "AUG",
+        9 => "SEP",
+        10 => "OCT",
+        11 => "NOV",
+        12 => "DEC",
+        _ => "???",
+    }
+}
+
 /// Render the face of the clock onto the provided DrawTarget.
 pub fn get_clock(time: DateTime<Local>, canvas: &mut impl Displays) {
     let minute = time.minute();
     let hour = time.hour();
-    let second = time.second();
-    let time = format!("{hour:02}:{minute:02}:{second:02}");
+    let day = time.day();
+    let month = month_en3(time.month());
+    let year = time.year() % 100;
+    let time = format!("{hour:02}:{minute:02}");
+    let date = format!("{day:02}{month}{year:02}");
 
     let mut canvas = canvas.face();
     Rectangle::new(Point::new(0, 0), Size::new(32, 16))
@@ -29,14 +52,18 @@ pub fn get_clock(time: DateTime<Local>, canvas: &mut impl Displays) {
         )
         .draw(&mut canvas)
         .expect("infallible");
-    // five 6x10 characters in a 32x16 space:
-    // 30 pixels wide, 1 on each side;
-    // I don't know how they're handling the vertical but this looks right.
-    //
-    // Using a smaller one so the seconds show up...
-    let mono_text_style = MonoTextStyle::new(&FONT_4X6, Rgb888::WHITE);
-    let style = mono_text_style;
-    Text::new(&time, Point::new(1, 11), style)
+
+    let time_style = MonoTextStyle::new(&FONT_6X9, Rgb888::WHITE);
+    let date_style = MonoTextStyle::new(&FONT_4X6, Rgb888::WHITE);
+    let style = TextStyleBuilder::new()
+        .alignment(Alignment::Center)
+        .baseline(Baseline::Top)
+        .build();
+
+    Text::with_text_style(&time, Point::new(15, 0), time_style, style)
+        .draw(&mut canvas)
+        .expect("infallible");
+    Text::with_text_style(&date, Point::new(15, 11), date_style, style)
         .draw(&mut canvas)
         .expect("infallible");
 }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -14,6 +14,7 @@ pub mod context;
 
 pub mod edge;
 pub mod face;
+pub mod riseset;
 
 #[cfg(feature = "simulator")]
 pub mod simulator;

--- a/server/src/riseset.rs
+++ b/server/src/riseset.rs
@@ -1,0 +1,84 @@
+//! Sunrise / sunset calculations.
+//!
+//! Equations are derived from two resources from
+//! [NOAA](https://gml.noaa.gov/grad/solcalc/calcdetails.html).
+//! I started with [this equations sheet](https://gml.noaa.gov/grad/solcalc/solareqns.PDF),
+//! but got results inconsistent with other sources.
+//!
+//! The spreadsheets on [this page](https://gml.noaa.gov/grad/solcalc/calcdetails.html)
+//! align with other sources.
+//!
+
+/*
+Spreadsheet computation:
+
+Sunrise is (X2 * 1440 - W2 * 4) / 1440 (fraction of a day)
+Sunset is (X2 * 1440 + W2 * 4) / 1440
+
+W2: HA of sunrise (in degrees)
+X2: Solar noon:
+    720 - 4 * longitude + tzoffset - V2
+V2: equation of time
+
+*/
+
+use std::f64::consts::PI;
+
+use chrono::{DateTime, Datelike, Duration, NaiveDateTime, NaiveTime, Timelike};
+
+pub fn riseset<T: chrono::TimeZone>(
+    date: DateTime<T>,
+    latitude: f64,
+    longitude: f64,
+) -> (DateTime<T>, DateTime<T>, DateTime<T>) {
+    let yr = date.year();
+    // The NOAA equations produce rise and set times in minutes past UTC midnight.
+    // We'll complete the NOAA equations then convert back to DateTime.
+    let (rise, snoon, set) = {
+        // START OF NOAA EQUATIONS
+        let leap_year = yr % 4 == 0 && yr % 100 != 0;
+
+        let days = if leap_year { 366 } else { 365 };
+
+        // Fractional year in radians
+        let ordinal_day = date.ordinal() - 1 + (date.hour() - 12) / 24;
+        let gamma = (2.0 * PI) * (ordinal_day as f64) / (days as f64);
+
+        // equation of time, relating mean solar time and true solar time
+        let eqtime = 229.18
+            * (0.000075 + 0.001868 * gamma.cos()
+                - 0.032077 * gamma.sin()
+                - 0.014615 * (2.0 * gamma).cos()
+                - 0.040849 * (2.0 * gamma).sin());
+
+        // solar declination angle (in radians):
+        let decl = 0.006918 - 0.399912 * (gamma).cos() + 0.070257 * (gamma).sin()
+            - 0.006758 * (2.0 * gamma).cos()
+            + 0.000907 * (2.0 * gamma).sin()
+            - 0.002697 * (3.0 * gamma).cos()
+            + 0.00148 * (3.0 * gamma).sin();
+
+        // The hour angle of the sunrise and sunset is:
+        let zenith: f64 = (90.833f64).to_radians();
+        let lat = latitude.to_radians();
+
+        // We diverge from the PDF here and use the spreadsheet's form:
+        // rise and set are computed as a difference from solar noon.
+        let ha = (zenith.cos() / (lat.cos() * decl.cos()) - lat.tan() * decl.tan()).acos();
+
+        let snoon = 720.0 - 4.0 * longitude - eqtime;
+        let rise = snoon - 4.0 * ha.to_degrees();
+        let set = snoon + 4.0 * ha.to_degrees();
+
+        (rise, snoon, set)
+        // END OF NOAA EQUATIONS
+    };
+    let just_date = date.naive_utc().date();
+    let [rise, snoon, set] = [rise, snoon, set].map(|f| {
+        let offset = Duration::seconds(f.round() as i64 * 60);
+        let d = NaiveDateTime::new(just_date, NaiveTime::MIN) + offset;
+        date.timezone().from_utc_datetime(&d)
+    });
+
+    (rise, snoon, set)
+}


### PR DESCRIPTION
Add a generator for a preview video on a 1-year scale.
Replace the satkit implementation (and dependency tree)
with an implementation of the NOAA algorithms.

- feat: video generator and experiments with rise-set
- fix: add missing cargo.toml for linker config
- fix: drop satkit, adopt NOAA algorithms
